### PR TITLE
Update regex to fix #29

### DIFF
--- a/sphinx_markdown_tables/__init__.py
+++ b/sphinx_markdown_tables/__init__.py
@@ -24,7 +24,7 @@ def process_tables(app, docname, source):
     table_processor = markdown.extensions.tables.TableProcessor(md.parser)
 
     raw_markdown = source[0]
-    blocks = re.split(r'(\n{2,})', raw_markdown)
+    blocks = re.split(r'((?:.*\|.*\n){2,}(?:.*\|.*)*)', raw_markdown)
 
     for i, block in enumerate(blocks):
         if table_processor.test(None, block):

--- a/tests/test_process_tables.py
+++ b/tests/test_process_tables.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import sphinx_markdown_tables as m
+
+
+markdown_strings = [
+'''# Test
+
+|aaa|bbb|aaa|ddd|
+|---|---|---|---|
+|1|2|3|4|
+''',
+
+'''| First Header  | Second Header |
+| ------------- | ------------- |
+| Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  |
+''',
+# The next one fails with orig regex, but passes with the new regex
+'''# Test
+|aaa|bbb|aaa|ddd|
+|---|---|---|---|
+|1|2|3|4|''',
+    ]
+
+
+def test_process_tables(markdown_string):
+    source = [markdown_string]
+    m.process_tables(None, None, source)
+    assert '<table' in source[0]
+
+
+def pytest_generate_tests(metafunc):
+    if 'markdown_string' in metafunc.fixturenames:
+        metafunc.parametrize("markdown_string", markdown_strings)


### PR DESCRIPTION
@ryanfox , I've updated the regex to handle the case where there is no blank line before the table, as well as added a simple pytest test case for the fix in `tests/`. Please let me know if you have any feedback.